### PR TITLE
allow flexible sailsd client config

### DIFF
--- a/sails-ui-web
+++ b/sails-ui-web
@@ -51,7 +51,9 @@ async def wshandler(request):
 
 async def listen_to_sailsd(app):
     try:
-        sails = sailsd.Sailsd()
+        host = os.getenv('SAILSD_HOST', 'localhost')
+        port = int(os.getenv('SAILSD_PORT', '3333'))
+        sails = sailsd.Sailsd(host, port)
         while True:
             for ws in app["sockets"]:
                 ws.send_str(json.dumps(


### PR DESCRIPTION
Dovetails with this change on `python-sailsd` https://github.com/sails-simulator/python-sailsd/pull/3 - that enables the sailsd host/port to be configured dynamically.